### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "handlebars": "^4.1.2",
     "jquery": "^3.4.1",
-    "normalize-scss": "^7.0.1",
-    "npm": "^6.9.0"
+    "normalize-scss": "^7.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",


### PR DESCRIPTION

Hello RDemian!

It seems like you have npm as one of your (dev-) dependency in component-markup-1.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
